### PR TITLE
Fix for potential nil strings during -drawRect: on iOS 6.

### DIFF
--- a/FontasticIcons/Sources/Classes/FIIconView.m
+++ b/FontasticIcons/Sources/Classes/FIIconView.m
@@ -30,7 +30,7 @@
         self.iconColor = [UIColor blackColor];
     }
     CGColorRef color = self.iconColor.CGColor;
-    NSString *iconString = self.icon.iconString;
+    NSString *iconString = (self.icon.iconString) ? self.icon.iconString : @"";
     NSDictionary *attributesDict = [NSDictionary dictionaryWithObjectsAndKeys:
                                     (id)font, (NSString *)kCTFontAttributeName,
                                     color, (NSString *)kCTForegroundColorAttributeName,


### PR DESCRIPTION
This never gave me fits on iOS 5, but if there was ever an instance where an `FIIconView` was being rendered without an icon string set, the call to create the `NSAttributedString` `attrString` would fail (as `iconString` would still be `nil`). By setting `iconString` to a blank string if `iconString` was a falsy value (as in, being `nil`), everything else ends up going smoothly in `drawRect:`.

I'm not sure why this was an issue for me in iOS 6 but not in iOS 5 (perhaps it's due to UIKit changes in `NSMutableAttributedString`?), but I never even saw a blank icon using this fix.

_Also, thank you so much for your awesome work with this library. I wish I could have discovered it sooner, as it's saved me tons of time already!_
