### PR TITLE
This resolves #29.

### DIFF
--- a/FontasticIcons.podspec
+++ b/FontasticIcons.podspec
@@ -7,10 +7,10 @@ Pod::Spec.new do |s|
                     - [FontAwesome](http://fortawesome.github.com/Font-Awesome/) by Dave Gandy
                     - [Iconic](http://somerandomdude.com/work/iconic/) font by P.J. Onori
                    DESC
-  s.homepage     = 'https://github.com/AlexDenisov/FontasticIcons'
+  s.homepage     = 'https://github.com/eddy-lau/FontasticIcons'
   s.license      = 'MIT'
   s.author       = { 'Alex Denisov' => '1101.debian@gmail.com' }
-  s.source       = { :git => 'https://github.com/AlexDenisov/FontasticIcons.git', :tag => "#{s.version}" }
+  s.source       = { :git => 'https://github.com/eddy-lau/FontasticIcons.git', :tag => "#{s.version}" }
   s.platform     = :ios, '4.2'
   s.source_files = 'FontasticIcons/Sources/Classes'
   s.resources    = 'FontasticIcons/Sources/Resources/**'

--- a/FontasticIcons.podspec
+++ b/FontasticIcons.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FontasticIcons'
-  s.version      = '0.5.1'
+  s.version      = '0.5.2'
   s.summary      = 'Objective-C wrapper for iconic fonts.'
   s.description  = <<-DESC
                     - [Entypo](http://entypo.com) pictograms by Daniel Bruce

--- a/FontasticIcons.podspec
+++ b/FontasticIcons.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FontasticIcons'
-  s.version      = '0.3.1'
+  s.version      = '0.3.2'
   s.summary      = 'Objective-C wrapper for iconic fonts.'
   s.description  = <<-DESC
                     - [Entypo](http://entypo.com) pictograms by Daniel Bruce

--- a/FontasticIcons.podspec
+++ b/FontasticIcons.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FontasticIcons'
-  s.version      = '0.3.2'
+  s.version      = '0.5.1'
   s.summary      = 'Objective-C wrapper for iconic fonts.'
   s.description  = <<-DESC
                     - [Entypo](http://entypo.com) pictograms by Daniel Bruce

--- a/FontasticIcons/Sources/Classes/FIFont.m
+++ b/FontasticIcons/Sources/Classes/FIFont.m
@@ -87,8 +87,30 @@ static NSMutableDictionary *fonts;
 }
 
 + (NSString *)pathForResource:(NSString *)aPath {
-    return [[NSBundle bundleForClass:self] pathForResource:aPath.stringByDeletingPathExtension.lastPathComponent
-                                           ofType:aPath.pathExtension];
+
+    NSBundle *bundle = [NSBundle bundleForClass:self];
+
+    NSString *resourcePath =
+        [bundle pathForResource:aPath.stringByDeletingPathExtension.lastPathComponent
+                         ofType:aPath.pathExtension];
+
+    if (resourcePath == nil) {
+
+        resourcePath =
+            [bundle pathForResource:aPath.stringByDeletingPathExtension.lastPathComponent
+                             ofType:aPath.pathExtension inDirectory:@"Fonts"];
+
+    }
+
+    if (resourcePath == nil) {
+
+        resourcePath =
+        [bundle pathForResource:aPath.stringByDeletingPathExtension.lastPathComponent
+                         ofType:aPath.pathExtension inDirectory:@"Strings"];
+
+    }
+
+    return resourcePath;
 }
 
 @end

--- a/FontasticIcons/Sources/Classes/FIFont.m
+++ b/FontasticIcons/Sources/Classes/FIFont.m
@@ -87,7 +87,7 @@ static NSMutableDictionary *fonts;
 }
 
 + (NSString *)pathForResource:(NSString *)aPath {
-    return [[NSBundle mainBundle] pathForResource:aPath.stringByDeletingPathExtension.lastPathComponent
+    return [[NSBundle bundleForClass:self] pathForResource:aPath.stringByDeletingPathExtension.lastPathComponent
                                            ofType:aPath.pathExtension];
 }
 


### PR DESCRIPTION
If it is built as a frameworks, `[Bundle mainBundle]` returns the bundle of the app instead of the built framework. This fix corrects this issue and returns the correct bundle.